### PR TITLE
Add AI scoring for documentation uploads

### DIFF
--- a/src/main/java/com/smartventure/smartventure/controller/DocumentationController.java
+++ b/src/main/java/com/smartventure/smartventure/controller/DocumentationController.java
@@ -21,7 +21,7 @@ public class DocumentationController {
 
     @PostMapping
     public Mono<DocumentationDto> create(@RequestBody DocumentationDto dto) {
-        return service.create(dto);
+        return service.createAndProcess(dto);
     }
 
     @PatchMapping("/{id}/scores")


### PR DESCRIPTION
## Summary
- automatically run GigaChat on uploaded documentation
- update controller to call new service method

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688264cee47483309a00416d750b2188